### PR TITLE
Generate Unique id for RpcRequestMessage

### DIFF
--- a/WalletConnectSharp.NEthereum/Client/WalletConnectClient.cs
+++ b/WalletConnectSharp.NEthereum/Client/WalletConnectClient.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Nethereum.JsonRpc.Client;
 using Nethereum.JsonRpc.Client.RpcMessages;
 using WalletConnectSharp.Core;
+using WalletConnectSharp.Core.Utils;
 
 namespace WalletConnectSharp.NEthereum.Client
 {
@@ -18,7 +19,7 @@ namespace WalletConnectSharp.NEthereum.Client
 
         protected override async Task<RpcResponseMessage> SendAsync(RpcRequestMessage message, string route = null)
         {
-            _id += 1;
+            _id = RpcPayloadId.Generate();
             var mapParameters = message.RawParameters as Dictionary<string, object>;
             var arrayParameters = message.RawParameters as object[];
             var rawParameters = message.RawParameters;

--- a/WalletConnectSharp.NEthereum/Client/WalletConnectClient.cs
+++ b/WalletConnectSharp.NEthereum/Client/WalletConnectClient.cs
@@ -9,7 +9,6 @@ namespace WalletConnectSharp.NEthereum.Client
 {
     public class WalletConnectClient : ClientBase
     {
-        private long _id;
         public WalletConnectSession Session { get; }
 
         public WalletConnectClient(WalletConnectSession provider)
@@ -19,18 +18,18 @@ namespace WalletConnectSharp.NEthereum.Client
 
         protected override async Task<RpcResponseMessage> SendAsync(RpcRequestMessage message, string route = null)
         {
-            _id = RpcPayloadId.Generate();
+            long id = RpcPayloadId.Generate();
             var mapParameters = message.RawParameters as Dictionary<string, object>;
             var arrayParameters = message.RawParameters as object[];
             var rawParameters = message.RawParameters;
 
             RpcRequestMessage rpcRequestMessage;
             if (mapParameters != null) 
-                rpcRequestMessage = new RpcRequestMessage(_id, message.Method, mapParameters);
+                rpcRequestMessage = new RpcRequestMessage(id, message.Method, mapParameters);
             else if (arrayParameters != null)
-                rpcRequestMessage = new RpcRequestMessage(_id, message.Method, arrayParameters);
+                rpcRequestMessage = new RpcRequestMessage(id, message.Method, arrayParameters);
             else
-                rpcRequestMessage = new RpcRequestMessage(_id, message.Method, rawParameters);
+                rpcRequestMessage = new RpcRequestMessage(id, message.Method, rawParameters);
 
             TaskCompletionSource<RpcResponseMessage> eventCompleted = new TaskCompletionSource<RpcResponseMessage>(TaskCreationOptions.None);
             


### PR DESCRIPTION
Always generate a unique id for the RpcRequestMessage. If a session got resumed the request id could already be in use.