### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    open-pull-requests-limit: 2
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    allow:
+      - dependency-type: "direct"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Add `Dependabot` script to repo to help manage dependency updates with the following constraints:

- Limit 2 PRs the bot keeps open at once.
- Run check once a week. Can be run manually from settings otherwise.