### PR TITLE
Enforce field ordering on JsonRpcRequest

### DIFF
--- a/WalletConnectSharp.Core/Models/Ethereum/EthSignTypedData.cs
+++ b/WalletConnectSharp.Core/Models/Ethereum/EthSignTypedData.cs
@@ -8,7 +8,7 @@ namespace WalletConnectSharp.Core.Models.Ethereum
 {
     public sealed class EthSignTypedData<T> : JsonRpcRequest
     {
-        [JsonProperty("params")] 
+        [JsonProperty("params", Order = 4)]
         private string[] _parameters;
         
         public EthSignTypedData(string address, T data, EIP712Domain domain)

--- a/WalletConnectSharp.Core/Models/JsonRpcRequest.cs
+++ b/WalletConnectSharp.Core/Models/JsonRpcRequest.cs
@@ -5,12 +5,12 @@ namespace WalletConnectSharp.Core.Models
 {
     public class JsonRpcRequest : IEventSource
     {
-        [JsonProperty]
+        [JsonProperty(Order = 1)]
         private long id;
-        [JsonProperty]
+        [JsonProperty(Order = 2)]
         private string jsonrpc = "2.0";
         
-        [JsonProperty("method")]
+        [JsonProperty("method", Order = 3)]
         public virtual string Method { get; protected set; }
 
         public JsonRpcRequest()


### PR DESCRIPTION
while the field ordering is already alphabetical, this enforces the order using the order property of the JsonProperty attribute