### PR TITLE
Feature/session protected methods

### DIFF
--- a/WalletConnectSharp.Core/WalletConnectProtocol.cs
+++ b/WalletConnectSharp.Core/WalletConnectProtocol.cs
@@ -60,9 +60,9 @@ namespace WalletConnectSharp.Core
             }
         }
 
-        public ITransport Transport { get; private set; }
+        public ITransport Transport { get; protected set; }
 
-        public ICipher Cipher { get; private set; }
+        public ICipher Cipher { get; protected set; }
         
         public ClientMeta DappMetadata { get; set; }
         
@@ -195,14 +195,14 @@ namespace WalletConnectSharp.Core
             await SetupTransport();
         }
         
-        public async Task SubscribeAndListenToTopic(string topic)
+        public virtual async Task SubscribeAndListenToTopic(string topic)
         {
             await Transport.Subscribe(topic);
             
             ListenToTopic(topic);
         }
 
-        public void ListenToTopic(string topic)
+        public virtual void ListenToTopic(string topic)
         {
             if (!_activeTopics.Contains(topic))
             {
@@ -210,7 +210,7 @@ namespace WalletConnectSharp.Core
             }
         }
 
-        private async void TransportOnMessageReceived(object sender, MessageReceivedEventArgs e)
+        protected async void TransportOnMessageReceived(object sender, MessageReceivedEventArgs e)
         {
             var networkMessage = e.Message;
 
@@ -236,7 +236,7 @@ namespace WalletConnectSharp.Core
             }
         }
 
-        public async Task<TR> SendRequestAwaitResponse<T, TR>(T requestObject, object requestId, string sendingTopic = null,
+        public virtual async Task<TR> SendRequestAwaitResponse<T, TR>(T requestObject, object requestId, string sendingTopic = null,
             bool? forcePushNotification = null)
         {
             TaskCompletionSource<TR> response = new TaskCompletionSource<TR>(TaskCreationOptions.None);
@@ -251,7 +251,7 @@ namespace WalletConnectSharp.Core
             return await response.Task;
         }
 
-        public async Task SendRequest<T>(T requestObject, string sendingTopic = null, bool? forcePushNotification = null)
+        public virtual async Task SendRequest<T>(T requestObject, string sendingTopic = null, bool? forcePushNotification = null)
         {
             bool silent;
             if (forcePushNotification != null)

--- a/WalletConnectSharp.Core/WalletConnectProvider.cs
+++ b/WalletConnectSharp.Core/WalletConnectProvider.cs
@@ -53,7 +53,7 @@ namespace WalletConnectSharp.Core
             this.ParseUrl();
         }
 
-        private void ParseUrl()
+        protected void ParseUrl()
         {
             /*
              *  var topicEncode = WebUtility.UrlEncode(_handshakeTopic);

--- a/WalletConnectSharp.Core/WalletConnectSession.cs
+++ b/WalletConnectSharp.Core/WalletConnectSession.cs
@@ -279,7 +279,7 @@ namespace WalletConnectSharp.Core
             await ConnectSession();
         }
 
-        public async Task DisconnectSession(string disconnectMessage = "Session Disconnected", bool createNewSession = true)
+        public virtual async Task DisconnectSession(string disconnectMessage = "Session Disconnected", bool createNewSession = true)
         {
             EnsureNotDisconnected();
             
@@ -599,7 +599,7 @@ namespace WalletConnectSharp.Core
         /// Creates and returns a serializable class that holds all session data required to resume later
         /// </summary>
         /// <returns></returns>
-        public SavedSession SaveSession()
+        public virtual SavedSession SaveSession()
         {
             if (!SessionConnected || Disconnected)
             {

--- a/WalletConnectSharp.Core/WalletConnectSession.cs
+++ b/WalletConnectSharp.Core/WalletConnectSession.cs
@@ -55,6 +55,9 @@ namespace WalletConnectSharp.Core
             }
         }
         
+        /// <summary>
+        /// Create a WalletConnect Session from a SavedSession
+        /// </summary>
         public WalletConnectSession(SavedSession savedSession, ITransport transport = null, ICipher cipher = null, EventDelegator eventDelegator = null) : base(savedSession, transport, cipher, eventDelegator)
         {
             this.DappMetadata = savedSession.DappMeta;
@@ -72,6 +75,9 @@ namespace WalletConnectSharp.Core
             this.SessionConnected = true;
         }
 
+        /// <summary>
+        /// Create a new WalletConnect Session
+        /// </summary>
         public WalletConnectSession(ClientMeta clientMeta, string bridgeUrl = null, ITransport transport = null, ICipher cipher = null, int chainId = 1, EventDelegator eventDelegator = null) : base(transport, cipher, eventDelegator)
         {
             if (clientMeta == null)
@@ -120,7 +126,7 @@ namespace WalletConnectSharp.Core
             CreateNewSession();
         }
 
-        private void CreateNewSession()
+        protected void CreateNewSession()
         {
             if (SessionConnected)
             {
@@ -146,7 +152,7 @@ namespace WalletConnectSharp.Core
             ReadyForUserPrompt = false;
         }
 
-        private void EnsureNotDisconnected()
+        protected void EnsureNotDisconnected()
         {
             if (Disconnected)
             {
@@ -155,7 +161,7 @@ namespace WalletConnectSharp.Core
             }
         }
         
-        private void GenerateKey()
+        protected void GenerateKey()
         {
             //Generate a random secret
             byte[] secret = new byte[32];
@@ -450,7 +456,7 @@ namespace WalletConnectSharp.Core
         /// Create a new WalletConnect session with a Wallet.
         /// </summary>
         /// <returns></returns>
-        private async Task<WCSessionData> CreateSession()
+        protected async Task<WCSessionData> CreateSession()
         {
             EnsureNotDisconnected();
             
@@ -511,7 +517,7 @@ namespace WalletConnectSharp.Core
             return response;
         }
 
-        private void HandleSessionResponse(object sender, JsonRpcResponseEvent<WCSessionRequestResponse> jsonresponse)
+        protected void HandleSessionResponse(object sender, JsonRpcResponseEvent<WCSessionRequestResponse> jsonresponse)
         {
             var response = jsonresponse.Response.result;
 
@@ -529,7 +535,7 @@ namespace WalletConnectSharp.Core
             }
         }
 
-        private void HandleSessionUpdate(WCSessionData data)
+        protected void HandleSessionUpdate(WCSessionData data)
         {
             if (data == null) return;
 
@@ -567,7 +573,7 @@ namespace WalletConnectSharp.Core
                 SessionUpdate(this, data);
         }
 
-        private void HandleSessionDisconnect(string msg, string topic = "disconnect", bool createNewSession = true)
+        protected void HandleSessionDisconnect(string msg, string topic = "disconnect", bool createNewSession = true)
         {
             SessionConnected = false;
             Disconnected = true;


### PR DESCRIPTION
This PR exposes the internal methods of WalletConnectProtocol and WalletConnectSession using the protected modifier instead of the private modifier. In my testing I've run into a few cases where I've needed to override some of these values and I've had to make modifications internally and push a package update locally in order to test the changes. I've also set most public methods to virtual so that they can be overridden by derivative classes as necessary.

I'm not sure if this is in line with your long term goals for the library or not, but it has been useful for me.