### PR TITLE
Add PR workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,23 @@
+name: PR Build
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+    - name: Restore dependencies
+      run: dotnet restore
+      working-directory: ./
+    - name: Build
+      run: dotnet build --no-restore
+      working-directory: ./
+    - name: Test
+      run: dotnet test --no-build --verbosity normal
+      working-directory: ./


### PR DESCRIPTION
Closes #38.  

Notes:
- `ubuntu-latest` does have a version of .NET 6 installed, just not the latest. Currently docs say it is v6.0.302
- This could, technically, use the same file as the workflow that manages pushes to `main`. Long term, I'd expect the two scripts to diverge, so starting with them split