### PR TITLE
Fix/obsolete hex conversion & replace socket conversion consistently

### DIFF
--- a/WalletConnectSharp.Core/Network/AESCipher.cs
+++ b/WalletConnectSharp.Core/Network/AESCipher.cs
@@ -64,9 +64,9 @@ public class AESCipher : ICipher
         if (encoding == null)
             encoding = Encoding.UTF8;
 
-        byte[] rawData = encryptedData.data.FromHex();
-        byte[] iv = encryptedData.iv.FromHex();
-        byte[] hmacReceived = encryptedData.hmac.FromHex();
+        byte[] rawData = encryptedData.data.HexToByteArray();
+        byte[] iv = encryptedData.iv.HexToByteArray();
+        byte[] hmacReceived = encryptedData.hmac.HexToByteArray();
 
         using (HMACSHA256 hmac = new HMACSHA256(key))
         {

--- a/WalletConnectSharp.Core/Network/DefaultBridge.cs
+++ b/WalletConnectSharp.Core/Network/DefaultBridge.cs
@@ -1,3 +1,5 @@
+using WalletConnectSharp.Core.Utils;
+
 namespace WalletConnectSharp.Core.Network;
 
 public static class DefaultBridge
@@ -61,10 +63,10 @@ public static class DefaultBridge
         if (ExtractRootDomain(url) == Domain)
         {
             var chosen = ChooseRandomBridge();
-            if (url.StartsWith("wss"))
-                chosen = chosen.Replace("https", "wss");
-            else if (url.StartsWith("ws"))
-                chosen = chosen.Replace("http", "ws");
+            if (url.StartsWith(UriSchemes.UriSchemeWss))
+                chosen = chosen.Replace(Uri.UriSchemeHttps, UriSchemes.UriSchemeWss);
+            else if (url.StartsWith(UriSchemes.UriSchemeWs))
+                chosen = chosen.Replace(Uri.UriSchemeHttp, UriSchemes.UriSchemeWs);
             return chosen;
         }
         return url;

--- a/WalletConnectSharp.Core/Network/DefaultBridge.cs
+++ b/WalletConnectSharp.Core/Network/DefaultBridge.cs
@@ -59,7 +59,14 @@ public static class DefaultBridge
     public static string GetBridgeUrl(string url)
     {
         if (ExtractRootDomain(url) == Domain)
-            return ChooseRandomBridge();
+        {
+            var chosen = ChooseRandomBridge();
+            if (url.StartsWith("wss"))
+                chosen = chosen.Replace("https", "wss");
+            else if (url.StartsWith("ws"))
+                chosen = chosen.Replace("http", "ws");
+            return chosen;
+        }
         return url;
     }
 }

--- a/WalletConnectSharp.Core/Utils/Hex.cs
+++ b/WalletConnectSharp.Core/Utils/Hex.cs
@@ -144,7 +144,7 @@ public static class HexByteConvertorExtensions
         return value;
     }
 
-    [Obsolete]
+    [Obsolete("use the builtin string.HexToByteArray. This method will be removed in a future release.")]
     public static byte[] FromHex(this string value)
     {
         return value.HexToByteArray();

--- a/WalletConnectSharp.Core/Utils/UriSchemes.cs
+++ b/WalletConnectSharp.Core/Utils/UriSchemes.cs
@@ -1,0 +1,12 @@
+namespace WalletConnectSharp.Core.Utils
+{
+    /// <summary>
+    /// This is a helper class for URI related schemes that are not in .Net Standard 2.1.
+    /// TODO: Remove this class when Unity supports .Net > 6.0.0
+    /// </summary>
+    public static class UriSchemes
+    {
+        public static readonly string UriSchemeWs = "ws";
+        public static readonly string UriSchemeWss = "wss";
+    }
+}

--- a/WalletConnectSharp.Core/WalletConnectProvider.cs
+++ b/WalletConnectSharp.Core/WalletConnectProvider.cs
@@ -97,7 +97,7 @@ public class WalletConnectProvider : WalletConnectProtocol
                     break;
                 case "key":
                     base._key = WebUtility.UrlDecode(value);
-                    base._keyRaw = base._key.FromHex();
+                    base._keyRaw = base._key.HexToByteArray();
                     break;
             }
         }

--- a/WalletConnectSharp.Core/WalletConnectSession.cs
+++ b/WalletConnectSharp.Core/WalletConnectSession.cs
@@ -107,11 +107,6 @@ public class WalletConnectSession : WalletConnectProtocol
 
         bridgeUrl = DefaultBridge.GetBridgeUrl(bridgeUrl);
 
-        if (bridgeUrl.StartsWith("https"))
-            bridgeUrl = bridgeUrl.Replace("https", "wss");
-        else if (bridgeUrl.StartsWith("http"))
-            bridgeUrl = bridgeUrl.Replace("http", "ws");
-
         this.DappMetadata = clientMeta;
         this.ChainId = chainId;
         this._bridgeUrl = bridgeUrl;
@@ -128,7 +123,7 @@ public class WalletConnectSession : WalletConnectProtocol
             throw new IOException("You cannot create a new session after connecting the session. Create a new WalletConnectSession object to create a new session");
         }
 
-            this._bridgeUrl = DefaultBridge.GetBridgeUrl(this._bridgeUrl);
+        this._bridgeUrl = DefaultBridge.GetBridgeUrl(this._bridgeUrl);
 
         var topicGuid = Guid.NewGuid();
 


### PR DESCRIPTION
removes the references for `FromHex` in favor of the builtin method. Move the socket protocol string replacement for the bridge url into the `GetBridgeUrl` method so that it is consistently applied from both call sites.