### PR TITLE
Upgrade Nethereum to 4.8.0 and refactor EIP-712 signatures

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
             "program": "${workspaceFolder}/Examples/console/bin/Debug/net6.0/WalletConnectSharp.Examples.dll",
-            "args": ["nethereum_send_tx_example"],
+            "args": ["sign_typed_data_example"],
             "cwd": "${workspaceFolder}/Examples/console",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,10 +3,12 @@
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     </PropertyGroup>
     <ItemGroup>
-        <PackageVersion Include="Nethereum.JsonRpc.RpcClient" Version="4.7.0" />
-        <PackageVersion Include="Nethereum.RLP"               Version="4.7.0" />
-        <PackageVersion Include="Nethereum.RPC"               Version="4.7.0" />
-        <PackageVersion Include="Nethereum.Web3"              Version="4.7.0" />
+        <PackageVersion Include="Nethereum.JsonRpc.RpcClient" Version="4.8.0" />
+        <PackageVersion Include="Nethereum.RLP"               Version="4.8.0" />
+        <PackageVersion Include="Nethereum.RPC"               Version="4.8.0" />
+        <PackageVersion Include="Nethereum.Web3"              Version="4.8.0" />
+        <PackageVersion Include="Nethereum.Signer"            Version="4.8.0" />
+        <PackageVersion Include="Nethereum.Signer.EIP712"     Version="4.8.0" />
     </ItemGroup>
     <ItemGroup>
         <PackageVersion Include="Newtonsoft.Json"             Version="13.0.1" />

--- a/Examples/console/Examples/SignTypedDataExample.cs
+++ b/Examples/console/Examples/SignTypedDataExample.cs
@@ -1,0 +1,168 @@
+using System.Numerics;
+using System.Diagnostics;
+using Nethereum.ABI.FunctionEncoding.Attributes;
+using Nethereum.Signer.EIP712;
+using Newtonsoft.Json;
+using WalletConnectSharp.Core.Models;
+using WalletConnectSharp.Core.Models.Ethereum.Types;
+using WalletConnectSharp.Desktop;
+using WalletConnectSharp.NEthereum;
+using Nethereum.ABI.EIP712;
+
+namespace WalletConnectSharp.Examples.Examples;
+
+[Struct("Message")]
+public class Message
+{
+    [EvmType("string", "stringValue", 1)]
+    [JsonProperty("stringValue", Order = 1)]
+    [Parameter("string", "stringValue", 1)]
+    public string StringValue { get; set; }
+
+    [EvmType("address", "addressValue", 2)]
+    [JsonProperty("addressValue", Order = 2)]
+    [Parameter("address", "addressValue", 2)]
+    public string AddressValue { get; set; }
+
+    [EvmType("uint8", "uint8Value", 3)]
+    [JsonProperty("uint8Value", Order = 3)]
+    [Parameter("uint8", "uint8Value", 3)]
+    public ushort Uint8Value { get; set; }
+
+    [EvmType("uint64", "uint64Value", 4)]
+    [JsonProperty("uint64Value", Order = 4)]
+    [Parameter("uint64", "uint64Value", 4)]
+    public ulong Uint64Value { get; set; }
+
+    [EvmType("uint256", "uint256Value", 5)]
+    [JsonProperty("uint256Value", Order = 5)]
+    [Parameter("uint256", "uint256Value", 5)]
+    public ulong Uint256Value { get; set; }
+}
+
+/// <summary>
+/// Example demonstrating different methods to sign typed data.
+/// </summary>
+public class SignTypedDataExample : IExample
+{
+
+    public string Name => "sign_typed_data_example";
+
+    public const string VerifyingContractName = "Some Contract Name";
+    public const string VerifyingContractVersion = "1.0";
+    public static BigInteger VerifyingContractChainId => new(1);
+    public const string VerifyingContractAddress = "0x0000000000000000000000000000000000000000";
+
+    public static EIP712Domain WalletConnectDomain => new()
+    {
+        Name = VerifyingContractName,
+        Version = VerifyingContractVersion,
+        ChainId = VerifyingContractChainId,
+        VerifyingContract = VerifyingContractAddress
+    };
+
+    public static Domain NethereumDomain => new()
+    {
+        Name = VerifyingContractName,
+        Version = VerifyingContractVersion,
+        ChainId = VerifyingContractChainId,
+        VerifyingContract = VerifyingContractAddress
+    };
+
+    public TypedData<Domain> NethereumSchema => new()
+    {
+        Domain = NethereumDomain,
+        Types = MemberDescriptionFactory.GetTypesMemberDescription(
+                typeof(Domain),
+                typeof(Message)
+            ),
+        PrimaryType = nameof(Message),
+    };
+
+    private static Eip712TypedDataSigner _signer => new();
+
+
+    public async Task Execute(string[] args)
+    {
+        // create client metadata
+        var clientMeta = new ClientMeta()
+        {
+            Name = "WalletConnectSharp",
+            Description = "An example that showcases how to use the WalletConnectSharp library",
+            Icons = new[] { "https://app.warriders.com/favicon.ico" },
+            URL = "https://app.warriders.com/"
+        };
+
+        // create a client
+        var client = new WalletConnect(clientMeta);
+
+        Console.WriteLine("Connect using the following URL");
+        Console.WriteLine(client.URI);
+
+        await client.Connect();
+
+        var account = Nethereum.Util.AddressUtil.Current.ConvertToChecksumAddress(client.Accounts[0]);
+
+        Console.WriteLine("The account " + account + " has connected!");
+
+        // create a message to sign
+        var message = new Message
+        {
+            StringValue = "Some String",
+            AddressValue = account,
+            Uint8Value = 123,
+            Uint64Value = 12345,
+            Uint256Value = 123456,
+        };
+
+        try
+        {
+            await Sign_With_WalletConnect_Serialization(client, account, message);
+            await Sign_With_Nethereum_Serialization(client, account, message);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex);
+        }
+        finally
+        {
+            await client.Disconnect();
+        }
+
+        Console.WriteLine($"{Name}: COMPLETE!");
+    }
+
+    private async Task Sign_With_WalletConnect_Serialization(WalletConnect client, string account, Message message)
+    {
+        Console.WriteLine($"Requesting Signature from {account}");
+
+        var signature = await client.EthSignTypedData(account, message, WalletConnectDomain);
+
+        Console.WriteLine($"WalletConnect signature: {signature}");
+
+        var recovered = _signer.RecoverFromSignatureV4(
+            message, NethereumSchema, signature);
+
+        Console.WriteLine($"WalletConnect recovered: {recovered}");
+
+        // assert the recovery matches the account
+        Debug.Assert(recovered == account);
+    }
+
+    private async Task Sign_With_Nethereum_Serialization(WalletConnect client, string account, Message message)
+    {
+        Console.WriteLine($"Requesting WC Signature from {account}");
+
+        var signature = await client.EthSignTypedData(account, message, NethereumSchema);
+
+        Console.WriteLine($"Nethereum signature: {signature}");
+
+        var recovered = _signer.RecoverFromSignatureV4(
+            message, NethereumSchema, signature);
+
+        Console.WriteLine($"Nethereum recovered: {recovered}");
+
+        // assert the recovery matches the account
+        Debug.Assert(recovered == account);
+    }
+}

--- a/Examples/console/Program.cs
+++ b/Examples/console/Program.cs
@@ -8,10 +8,11 @@ class Program
 {
     private static readonly IExample[] Examples = new IExample[]
     {
-            new NEthereumSendTransactionExample()
+            new NEthereumSendTransactionExample(),
+            new SignTypedDataExample()
     };
 
-    static void ShowHelp()
+    private static void ShowHelp()
     {
         Console.WriteLine("Please specify which example to run");
         foreach (var e in Examples)
@@ -20,7 +21,7 @@ class Program
         }
     }
 
-    static async Task Main(string[] args)
+    public static async Task Main(string[] args)
     {
         if (args.Length == 0)
         {
@@ -28,8 +29,8 @@ class Program
             return;
         }
 
-        string name = args[0];
-        string[] exampleArgs = args.Skip(1).ToArray();
+        var name = args[0];
+        var exampleArgs = args.Skip(1).ToArray();
 
         var example = Examples.FirstOrDefault(e => e.Name.ToLower() == name);
 

--- a/Examples/console/WalletConnectSharp.Examples.csproj
+++ b/Examples/console/WalletConnectSharp.Examples.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nethereum.Web3" />
+    <PackageReference Include="Nethereum.Signer.EIP712" />
   </ItemGroup>
 
 </Project>

--- a/WalletConnectSharp.Core/Extensions/DictionaryExtensions.cs
+++ b/WalletConnectSharp.Core/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,24 @@
+
+namespace WalletConnectSharp.Core.Extensions;
+
+public static class DictionaryExtensions
+{
+    /// <Summary>
+    /// Try to add the element to the dictionary if the key does not already exist.
+    /// </Summary>
+    public static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
+    {
+        if (dictionary == null)
+        {
+            throw new ArgumentNullException(nameof(dictionary));
+        }
+
+        if (!dictionary.ContainsKey(key))
+        {
+            dictionary.Add(key, value);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/WalletConnectSharp.Core/Models/Ethereum/Types/EIP712Domain.cs
+++ b/WalletConnectSharp.Core/Models/Ethereum/Types/EIP712Domain.cs
@@ -1,23 +1,35 @@
-using WalletConnectSharp.Core.Models.Ethereum.Types;
+using System.Numerics;
 
-namespace WalletConnectSharp.Core.Models;
+namespace WalletConnectSharp.Core.Models.Ethereum.Types;
 
 public class EIP712Domain
 {
-    public string name;
-    public string version;
+    [EvmType("string", "name", 1)]
+    [JsonProperty("name", Order = 1)]
+    public virtual string Name { get; set; }
 
-    [EvmIgnore]
-    public int chainId;
+    [EvmType("string", "version", 2)]
+    [JsonProperty("version", Order = 2)]
+    public virtual string Version { get; set; }
 
-    [EvmType("address")]
-    public string verifyingContract;
+    [EvmType("uint256", "chainId", 3)]
+    [JsonProperty("chainId", Order = 3)]
+    public virtual BigInteger? ChainId { get; set; }
+
+    [EvmType("address", "verifyingContract", 4)]
+    [JsonProperty("verifyingContract", Order = 4)]
+    public virtual string VerifyingContract { get; set; }
+
+    public EIP712Domain()
+    {
+
+    }
 
     public EIP712Domain(string name, string version, int chainId, string verifyingContract)
     {
-        this.name = name;
-        this.version = version;
-        this.chainId = chainId;
-        this.verifyingContract = verifyingContract;
+        Name = name;
+        Version = version;
+        ChainId = chainId;
+        VerifyingContract = verifyingContract;
     }
 }

--- a/WalletConnectSharp.Core/Models/Ethereum/Types/EvmTypeAttribute.cs
+++ b/WalletConnectSharp.Core/Models/Ethereum/Types/EvmTypeAttribute.cs
@@ -1,10 +1,18 @@
 namespace WalletConnectSharp.Core.Models.Ethereum.Types;
+
+[AttributeUsage(AttributeTargets.Property)]
 public class EvmTypeAttribute : Attribute
 {
-    public string TypeName { get; }
+    public string Type { get; }
 
-    public EvmTypeAttribute(string typename)
+    public string Name { get; }
+
+    public int Order { get; }
+
+    public EvmTypeAttribute(string typename, string name = null, int order = 1)
     {
-        TypeName = typename;
+        Type = typename;
+        Name = name;
+        Order = order;
     }
 }

--- a/WalletConnectSharp.Core/WalletConnectSession.cs
+++ b/WalletConnectSharp.Core/WalletConnectSession.cs
@@ -6,6 +6,7 @@ using WalletConnectSharp.Core.Events;
 using WalletConnectSharp.Core.Events.Request;
 using WalletConnectSharp.Core.Models;
 using WalletConnectSharp.Core.Models.Ethereum;
+using WalletConnectSharp.Core.Models.Ethereum.Types;
 using WalletConnectSharp.Core.Network;
 using WalletConnectSharp.Core.Utils;
 

--- a/WalletConnectSharp.NEthereum/Account/WalletConnectAccount.cs
+++ b/WalletConnectSharp.NEthereum/Account/WalletConnectAccount.cs
@@ -1,5 +1,6 @@
 using Nethereum.JsonRpc.Client;
 using Nethereum.RPC.Accounts;
+using Nethereum.RPC.AccountSigning;
 using Nethereum.RPC.NonceServices;
 using Nethereum.RPC.TransactionManagers;
 using WalletConnectSharp.Core;
@@ -8,23 +9,20 @@ namespace WalletConnectSharp.NEthereum.Account;
 
 public class WalletConnectAccount : IAccount
 {
-    private WalletConnectSession session;
+    private readonly WalletConnectSession _session;
 
-    public string Address
-    {
-        get
-        {
-            return session.Accounts[0];
-        }
-    }
+    public string Address => _session.Accounts[0];
 
-    public ITransactionManager TransactionManager { get; }
+    public ITransactionManager TransactionManager { get; protected set; }
     public INonceService NonceService { get; set; }
+
+    public IAccountSigningService AccountSigningService { get; }
 
     public WalletConnectAccount(WalletConnectSession session, IClient client, bool allowEthSign = false)
     {
-        this.session = session;
-        this.TransactionManager = new WalletConnectTransactionManager(client, session, this, allowEthSign);
-        this.NonceService = new InMemoryNonceService(session.Accounts[0], client);
+        _session = session;
+        TransactionManager = new WalletConnectTransactionManager(client, session, this, allowEthSign);
+        NonceService = new InMemoryNonceService(session.Accounts[0], client);
+        // TODO: ISSUE #54: Implement IAccountSigningService
     }
 }

--- a/WalletConnectSharp.NEthereum/Client/FallbackProvider.cs
+++ b/WalletConnectSharp.NEthereum/Client/FallbackProvider.cs
@@ -19,6 +19,7 @@ public class FallbackProvider : IClient
 
     public Task<RpcRequestResponseBatch> SendBatchRequestAsync(RpcRequestResponseBatch rpcRequestResponseBatch)
     {
+        // TODO: ISSUE #55: Implement SendBatchRequestAsync
         throw new NotImplementedException();
     }
 

--- a/WalletConnectSharp.NEthereum/Client/FallbackProvider.cs
+++ b/WalletConnectSharp.NEthereum/Client/FallbackProvider.cs
@@ -17,6 +17,11 @@ public class FallbackProvider : IClient
         _fallback = fallback;
     }
 
+    public Task<RpcRequestResponseBatch> SendBatchRequestAsync(RpcRequestResponseBatch rpcRequestResponseBatch)
+    {
+        throw new NotImplementedException();
+    }
+
     public Task SendRequestAsync(RpcRequest request, string route = null)
     {
         return ValidMethods.Contains(request.Method) ? _signer.SendRequestAsync(request, route) : _fallback.SendRequestAsync(request, route);

--- a/WalletConnectSharp.NEthereum/Model/NEthSignTypedData.cs
+++ b/WalletConnectSharp.NEthereum/Model/NEthSignTypedData.cs
@@ -1,0 +1,19 @@
+using Nethereum.RPC.Eth.DTOs;
+using Nethereum.ABI.EIP712;
+using Nethereum.Signer.EIP712;
+using Newtonsoft.Json;
+using WalletConnectSharp.Core.Models;
+using WalletConnectSharp.Core.Models.Ethereum;
+using WalletConnectSharp.Core.Models.Ethereum.Types;
+
+namespace WalletConnectSharp.NEthereum.Model;
+
+public sealed class NEthSignTypedData<T, TDomain> : EthGenericRequest<string> where TDomain : IDomain
+{
+    public NEthSignTypedData(string address, T data, TypedData<TDomain> typedData) : base(
+        ValidJsonRpcRequestMethods.EthSignTypedData,
+        address,
+        typedData.ToJson(data))
+    {
+    }
+}

--- a/WalletConnectSharp.NEthereum/WalletConnectSharp.NEthereum.csproj
+++ b/WalletConnectSharp.NEthereum/WalletConnectSharp.NEthereum.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Nethereum.JsonRpc.RpcClient" />
     <PackageReference Include="Nethereum.RLP" />
     <PackageReference Include="Nethereum.RPC" />
+    <PackageReference Include="Nethereum.Signer.EIP712" />
     <PackageReference Include="Nethereum.Web3" />
     <None Include="..\resources\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>


### PR DESCRIPTION
This PR refactors the support for EIP-712 signatures a bit to be more consistent with the way Netheruem works. It also adds support for using Nethereum to serialize the package payload, which includes more features (tuples, lists, etc.) when creating typed data signatures. The original internal method is left in place so that there is an option if Nethereum is not taken as a dependency.

This PR Fixes: #17 

This PR also opens up: issue #54 and issue #55

Additionally, a new example is added `sign_typed_data_example` which should fix #2 

## Implementation Details

The internal functionality of `EvmTypedData` expects that any `EvmTypeAttribute` instances should be applied to public instance properties. Previously it allowed private members and fields. This change was made for two reasons, first, since these payloads are basically DTO's its reasonable to assume that the serialized properties should be publicly readable. Second, because of the differences in the way reflection works between .net classic and .net standard, there were some cases where serialization was adding the auto-generated `BackingField` fields to the serialization payload. This simplifies the code cosiderably.

Also, the `EvmTypeAttribute` is modified to follow a pattern similar to Nethereum where a name can be specified. this makes it easier to compare payloads across other serialization implementations like web3.js/ethers.js and nethereum, etc. where the payloads may not be able to be modified.

lastly, the `TypeMap` was removed in favor of a list of valid string values. There is no longer a fallback that will coerce the evm type from the .net type. I removed this because of the requirements that serialization is opt-in.

overall, this PR doesn't really enhance the behavior of the built-in eip-712 signing (e.g. doesn't add tuples) but it does clarify how to use the feature, and provides an alternative with nethereum for more advanced use cases.