### PR TITLE
Fixing : 'output buffer too short'

### DIFF
--- a/Core Modules/WalletConnectSharp.Crypto/Crypto.cs
+++ b/Core Modules/WalletConnectSharp.Crypto/Crypto.cs
@@ -640,7 +640,7 @@ namespace WalletConnectSharp.Crypto
             aead.Init(false, new ParametersWithIV(new KeyParameter(symKey.HexToByteArray()), iv));
 
             using MemoryStream rawDecrypted = new MemoryStream();
-            byte[] temp = new byte[8024];
+            byte[] temp = new byte[@sealed.Length];
             int len = aead.ProcessBytes(@sealed, 0, @sealed.Length, temp, 0);
             
             if (len > 0)


### PR DESCRIPTION
![image](https://github.com/WalletConnect/WalletConnectSharp/assets/516789/badbacbb-2a58-436d-baad-c117a9823792)

Having a buffer over 8024 bytes throw error. I have increased the byte[] length. (byte[] temp = new byte[@sealed.Length]; instead of fixed sized byte[] temp = new byte[8024];)