### PR TITLE
Allow modules to be disposed

### DIFF
--- a/Core Modules/WalletConnectSharp.Common/IModule.cs
+++ b/Core Modules/WalletConnectSharp.Common/IModule.cs
@@ -5,7 +5,7 @@ namespace WalletConnectSharp.Common
     /// <summary>
     /// An interface that represents a module
     /// </summary>
-    public interface IModule /* : IDisposable */
+    public interface IModule : IDisposable
     {
         /// <summary>
         /// The name of this module

--- a/Core Modules/WalletConnectSharp.Common/Model/IsolatedModule.cs
+++ b/Core Modules/WalletConnectSharp.Common/Model/IsolatedModule.cs
@@ -38,5 +38,7 @@ namespace WalletConnectSharp.Common.Model
 
             activeModules.Add(_guid);
         }
+
+        public void Dispose() { }
     }
 }

--- a/Core Modules/WalletConnectSharp.Crypto/Crypto.cs
+++ b/Core Modules/WalletConnectSharp.Crypto/Crypto.cs
@@ -684,5 +684,10 @@ namespace WalletConnectSharp.Crypto
 
             return seed.HexToByteArray();
         }
+
+        public void Dispose()
+        {
+            KeyChain?.Dispose();
+        }
     }
 }

--- a/Core Modules/WalletConnectSharp.Crypto/KeyChain.cs
+++ b/Core Modules/WalletConnectSharp.Crypto/KeyChain.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Threading.Tasks;
-using WalletConnectSharp.Common;
 using WalletConnectSharp.Common.Model.Errors;
 using WalletConnectSharp.Common.Utils;
 using WalletConnectSharp.Crypto.Interfaces;
@@ -198,6 +194,12 @@ namespace WalletConnectSharp.Crypto
         private async Task SaveKeyChain()
         {
             await Storage.SetItem(StorageKey, this._keyChain);
+        }
+
+        public void Dispose()
+        {
+            _keyChain?.Clear();
+            Storage?.Dispose();
         }
     }
 }

--- a/Core Modules/WalletConnectSharp.Events/EventHandlerMap.cs
+++ b/Core Modules/WalletConnectSharp.Events/EventHandlerMap.cs
@@ -97,8 +97,10 @@ namespace WalletConnectSharp.Events
 
         public void Dispose()
         {
-            mapping.Clear();
-            mapping = null;
+            lock (_mappingLock)
+            {
+                mapping.Clear();
+            }
         }
     }
 }

--- a/Core Modules/WalletConnectSharp.Events/EventHandlerMap.cs
+++ b/Core Modules/WalletConnectSharp.Events/EventHandlerMap.cs
@@ -7,7 +7,7 @@ namespace WalletConnectSharp.Events
     /// A mapping of eventIds to EventHandler objects. This using a Dictionary as the backing datastore
     /// </summary>
     /// <typeparam name="TEventArgs">The type of EventHandler's argument to store</typeparam>
-    public class EventHandlerMap<TEventArgs>
+    public class EventHandlerMap<TEventArgs> : IDisposable
     {
         private Dictionary<string, EventHandler<TEventArgs>> mapping =
             new Dictionary<string, EventHandler<TEventArgs>>();
@@ -93,6 +93,12 @@ namespace WalletConnectSharp.Events
                     mapping.Remove(eventId);
                 }
             }
+        }
+
+        public void Dispose()
+        {
+            mapping.Clear();
+            mapping = null;
         }
     }
 }

--- a/Core Modules/WalletConnectSharp.Events/EventManager.cs
+++ b/Core Modules/WalletConnectSharp.Events/EventManager.cs
@@ -85,5 +85,15 @@ namespace WalletConnectSharp.Events
                 }
             }
         }
+
+        public void Dispose()
+        {
+            EventTriggers.Dispose();
+            lock (_managerLock)
+            {
+                if (_instances.ContainsKey(Context))
+                    _instances.Remove(Context);
+            }
+        }
     }
 }

--- a/Core Modules/WalletConnectSharp.Events/Interfaces/IEventProvider.cs
+++ b/Core Modules/WalletConnectSharp.Events/Interfaces/IEventProvider.cs
@@ -5,7 +5,7 @@ namespace WalletConnectSharp.Events
     /// provider can trigger any event for a given event data type.
     /// </summary>
     /// <typeparam name="T">The event data type this class triggers events with</typeparam>
-    public interface IEventProvider<in T>
+    public interface IEventProvider<in T> : IDisposable
     {
         /// <summary>
         /// Trigger the given event (using the event id) with the given event data.

--- a/Core Modules/WalletConnectSharp.Network/JsonRpcProvider.cs
+++ b/Core Modules/WalletConnectSharp.Network/JsonRpcProvider.cs
@@ -304,5 +304,11 @@ namespace WalletConnectSharp.Network
                 }
             }
         }
+
+        public void Dispose()
+        {
+            _connection?.Dispose();
+            _delegator?.Dispose();
+        }
     }
 }

--- a/Core Modules/WalletConnectSharp.Storage/InMemoryStorage.cs
+++ b/Core Modules/WalletConnectSharp.Storage/InMemoryStorage.cs
@@ -75,5 +75,10 @@ namespace WalletConnectSharp.Storage
                 throw WalletConnectException.FromType(ErrorType.NOT_INITIALIZED, "Storage");
             }
         }
+
+        public void Dispose()
+        {
+            Entries?.Clear();
+        }
     }
 }

--- a/Core Modules/WalletConnectSharp.Storage/Interfaces/IKeyValueStorage.cs
+++ b/Core Modules/WalletConnectSharp.Storage/Interfaces/IKeyValueStorage.cs
@@ -5,7 +5,7 @@ namespace WalletConnectSharp.Storage.Interfaces
     /// <summary>
     /// The storage module handles the storing by key value pairing. All of the functions are asynchronous 
     /// </summary>
-    public interface IKeyValueStorage
+    public interface IKeyValueStorage : IDisposable
     {
         /// <summary>
         /// Initialize the storage. This should load any data or prepare any connection required by the

--- a/WalletConnectSharp.Auth/Controllers/AuthEngine.cs
+++ b/WalletConnectSharp.Auth/Controllers/AuthEngine.cs
@@ -392,4 +392,8 @@ public partial class AuthEngine : IAuthEngine
             throw WalletConnectException.FromType(ErrorType.NOT_INITIALIZED, Name);
         }
     }
+
+    public void Dispose()
+    {
+    }
 }

--- a/WalletConnectSharp.Auth/WalletConnectAuthClient.cs
+++ b/WalletConnectSharp.Auth/WalletConnectAuthClient.cs
@@ -162,4 +162,14 @@ public class WalletConnectAuthClient : IAuthClient
 
         return false;
     }
+
+    public void Dispose()
+    {
+        Events?.Dispose();
+        Core?.Dispose();
+        AuthKeys?.Dispose();
+        PairingTopics?.Dispose();
+        Requests?.Dispose();
+        Engine?.Dispose();
+    }
 }

--- a/WalletConnectSharp.Core/Controllers/Expirer.cs
+++ b/WalletConnectSharp.Core/Controllers/Expirer.cs
@@ -377,5 +377,10 @@ namespace WalletConnectSharp.Core.Controllers
             
             return $"{targetType}:{key}";
         }
+
+        public void Dispose()
+        {
+            Events?.Dispose();
+        }
     }
 }

--- a/WalletConnectSharp.Core/Controllers/HeartBeat.cs
+++ b/WalletConnectSharp.Core/Controllers/HeartBeat.cs
@@ -1,10 +1,6 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using WalletConnectSharp.Core.Interfaces;
 using WalletConnectSharp.Core.Models.Heartbeat;
 using WalletConnectSharp.Events;
-using WalletConnectSharp.Events.Model;
 
 namespace WalletConnectSharp.Core.Controllers
 {
@@ -98,6 +94,11 @@ namespace WalletConnectSharp.Core.Controllers
         private void Pulse()
         {
             Events.Trigger(HeartbeatEvents.Pulse, PULSE_OBJECT);
+        }
+
+        public void Dispose()
+        {
+            Events?.Dispose();
         }
     }
 }

--- a/WalletConnectSharp.Core/Controllers/JsonRpcHistory.cs
+++ b/WalletConnectSharp.Core/Controllers/JsonRpcHistory.cs
@@ -323,5 +323,11 @@ namespace WalletConnectSharp.Core.Controllers
                 throw WalletConnectException.FromType(ErrorType.NOT_INITIALIZED, Name);
             }
         }
+
+        public void Dispose()
+        {
+            _core?.Dispose();
+            Events?.Dispose();
+        }
     }
 }

--- a/WalletConnectSharp.Core/Controllers/MessageTracker.cs
+++ b/WalletConnectSharp.Core/Controllers/MessageTracker.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using WalletConnectSharp.Common;
 using WalletConnectSharp.Common.Model.Errors;
 using WalletConnectSharp.Common.Utils;
 using WalletConnectSharp.Core.Interfaces;
@@ -186,6 +182,11 @@ namespace WalletConnectSharp.Core.Controllers
             {
                 throw WalletConnectException.FromType(ErrorType.NOT_INITIALIZED, this.Name);
             }
+        }
+
+        public void Dispose()
+        {
+            _core?.Dispose();
         }
     }
 }

--- a/WalletConnectSharp.Core/Controllers/Pairing.cs
+++ b/WalletConnectSharp.Core/Controllers/Pairing.cs
@@ -492,5 +492,11 @@ namespace WalletConnectSharp.Core.Controllers
                 });
             }
         }
+
+        public void Dispose()
+        {
+            Events?.Dispose();
+            Store?.Dispose();
+        }
     }
 }

--- a/WalletConnectSharp.Core/Controllers/Publisher.cs
+++ b/WalletConnectSharp.Core/Controllers/Publisher.cs
@@ -157,5 +157,11 @@ namespace WalletConnectSharp.Core.Controllers
                 return;
             }
         }
+
+        public void Dispose()
+        {
+            Events?.Dispose();
+            Relayer?.Dispose();
+        }
     }
 }

--- a/WalletConnectSharp.Core/Controllers/Publisher.cs
+++ b/WalletConnectSharp.Core/Controllers/Publisher.cs
@@ -46,6 +46,7 @@ namespace WalletConnectSharp.Core.Controllers
             }
         }
 
+        private readonly object _queueLock = new object();
         protected Dictionary<string, PublishParams> queue = new Dictionary<string, PublishParams>();
 
         /// <summary>
@@ -67,31 +68,48 @@ namespace WalletConnectSharp.Core.Controllers
 
         private async void CheckQueue()
         {
-            // Unroll here so we don't deal with "collection modified" errors
-            var keys = queue.Keys.ToArray();
-            
-            foreach (var key in keys)
+            List<PublishParams> temp = new List<PublishParams>();
+            lock (_queueLock)
             {
-                try
-                {
-                    if (!queue.ContainsKey(key)) continue;
-                    var @params = queue[key];
+                var keys = queue.Keys.ToArray();
 
-                    var hash = HashUtils.HashMessage(@params.Message);
-                    await RpcPublish(@params.Topic, @params.Message, @params.Options.TTL, @params.Options.Tag,
-                        @params.Options.Relay);
-                    OnPublish(hash);
-                }
-                catch (KeyNotFoundException)
+                foreach (var key in keys)
                 {
-                    // ignore ..
+                    try
+                    {
+                        if (string.IsNullOrWhiteSpace(key)) continue;
+                        if (!queue.ContainsKey(key)) continue;
+                        var @params = queue[key];
+
+                        temp.Add(@params);
+                        
+                        var hash = HashUtils.HashMessage(@params.Message);
+                        this.queue.Remove(hash);
+                    }
+                    catch (KeyNotFoundException)
+                    {
+                        // ignore ..
+                    }
                 }
+            }
+
+            foreach (var @params in temp)
+            {
+                var hash = HashUtils.HashMessage(@params.Message);
+                await RpcPublish(@params.Topic, @params.Message, @params.Options.TTL, @params.Options.Tag,
+                    @params.Options.Relay);
+                OnPublish(hash);
             }
         }
 
         private void OnPublish(string hash)
         {
-            this.queue.Remove(hash);
+            lock (_queueLock)
+            {
+                if (!this.queue.ContainsKey(hash)) return;
+                
+                this.queue.Remove(hash);
+            }
         }
 
         protected Task RpcPublish(string topic, string message, long ttl, long tag, ProtocolOptions relay)
@@ -151,7 +169,11 @@ namespace WalletConnectSharp.Core.Controllers
             };
 
             var hash = HashUtils.HashMessage(message);
-            queue.Add(hash, @params);
+            lock (_queueLock)
+            {
+                queue.Add(hash, @params);
+            }
+
             try
             {
                 await RpcPublish(topic, message, @params.Options.TTL, @params.Options.Tag, @params.Options.Relay)

--- a/WalletConnectSharp.Core/Controllers/Publisher.cs
+++ b/WalletConnectSharp.Core/Controllers/Publisher.cs
@@ -72,12 +72,20 @@ namespace WalletConnectSharp.Core.Controllers
             
             foreach (var key in keys)
             {
-                if (!queue.ContainsKey(key)) continue;
-                var @params = queue[key];
-                
-                var hash = HashUtils.HashMessage(@params.Message);
-                await RpcPublish(@params.Topic, @params.Message, @params.Options.TTL, @params.Options.Tag, @params.Options.Relay);
-                OnPublish(hash);
+                try
+                {
+                    if (!queue.ContainsKey(key)) continue;
+                    var @params = queue[key];
+
+                    var hash = HashUtils.HashMessage(@params.Message);
+                    await RpcPublish(@params.Topic, @params.Message, @params.Options.TTL, @params.Options.Tag,
+                        @params.Options.Relay);
+                    OnPublish(hash);
+                }
+                catch (KeyNotFoundException)
+                {
+                    // ignore ..
+                }
             }
         }
 

--- a/WalletConnectSharp.Core/Controllers/Relayer.cs
+++ b/WalletConnectSharp.Core/Controllers/Relayer.cs
@@ -487,5 +487,14 @@ namespace WalletConnectSharp.Core.Controllers
             WCLogger.Log("[Relayer] Restarting transport");
             await this.RestartTransport();
         }
+
+        public void Dispose()
+        {
+            Events?.Dispose();
+            // Core?.Dispose();
+            Subscriber?.Dispose();
+            Publisher?.Dispose();
+            Messages?.Dispose();
+        }
     }
 }

--- a/WalletConnectSharp.Core/Controllers/Store.cs
+++ b/WalletConnectSharp.Core/Controllers/Store.cs
@@ -309,5 +309,10 @@ namespace WalletConnectSharp.Core.Controllers
                 throw WalletConnectException.FromType(ErrorType.NOT_INITIALIZED, Name);
             }
         }
+
+        public void Dispose()
+        {
+            Core?.Dispose();
+        }
     }
 }

--- a/WalletConnectSharp.Core/Controllers/Subscriber.cs
+++ b/WalletConnectSharp.Core/Controllers/Subscriber.cs
@@ -654,5 +654,11 @@ namespace WalletConnectSharp.Core.Controllers
                 this.pending.Remove(sub.Topic);
             }
         }
+
+        public void Dispose()
+        {
+            _relayer?.Dispose();
+            Events?.Dispose();
+        }
     }
 }

--- a/WalletConnectSharp.Core/Controllers/TypedMessageHandler.cs
+++ b/WalletConnectSharp.Core/Controllers/TypedMessageHandler.cs
@@ -362,5 +362,10 @@ namespace WalletConnectSharp.Core.Controllers
             await this.Core.Relayer.Publish(topic, message, opts);
             await (await this.Core.History.JsonRpcHistoryOfType<T, TR>()).Resolve(payload);
         }
+
+        public void Dispose()
+        {
+            Events?.Dispose();
+        }
     }
 }

--- a/WalletConnectSharp.Sign/Engine.cs
+++ b/WalletConnectSharp.Sign/Engine.cs
@@ -741,5 +741,11 @@ namespace WalletConnectSharp.Sign
         {
             return Reject(proposalStruct.RejectProposal(error));
         }
+
+        public void Dispose()
+        {
+            Events?.Dispose();
+            Client?.Dispose();
+        }
     }
 }

--- a/WalletConnectSharp.Sign/Internals/EngineHandler.cs
+++ b/WalletConnectSharp.Sign/Internals/EngineHandler.cs
@@ -3,8 +3,6 @@ using WalletConnectSharp.Common.Logging;
 using WalletConnectSharp.Common.Model.Errors;
 using WalletConnectSharp.Common.Utils;
 using WalletConnectSharp.Core.Models.Expirer;
-using WalletConnectSharp.Core.Models.Pairing.Methods;
-using WalletConnectSharp.Core.Models.Relay;
 using WalletConnectSharp.Events.Model;
 using WalletConnectSharp.Network.Models;
 using WalletConnectSharp.Sign.Interfaces;

--- a/WalletConnectSharp.Sign/WalletConnectSignClient.cs
+++ b/WalletConnectSharp.Sign/WalletConnectSignClient.cs
@@ -405,5 +405,15 @@ namespace WalletConnectSharp.Sign
             await Proposal.Init();
             await Engine.Init();
         }
+
+        public void Dispose()
+        {
+            Events?.Dispose();
+            Core?.Dispose();
+            PairingStore?.Dispose();
+            Session?.Dispose();
+            Proposal?.Dispose();
+            PendingRequests?.Dispose();
+        }
     }
 }

--- a/WalletConnectSharp.Web3Wallet/Web3WalletClient.cs
+++ b/WalletConnectSharp.Web3Wallet/Web3WalletClient.cs
@@ -193,4 +193,10 @@ public class Web3WalletClient : IWeb3Wallet
             Engine.AuthError -= value;
         }
     }
+
+    public void Dispose()
+    {
+        Events?.Dispose();
+        Core?.Dispose();
+    }
 }


### PR DESCRIPTION
This should allow reuse of the `context` strings when `Dispose` is called before re-initializing