### PR TITLE
fix: no longer hide exceptions when loading session file

### DIFF
--- a/Core Modules/WalletConnectSharp.Storage/FileSystemStorage.cs
+++ b/Core Modules/WalletConnectSharp.Storage/FileSystemStorage.cs
@@ -110,23 +110,8 @@ namespace WalletConnectSharp.Storage
             await _semaphoreSlim.WaitAsync();
             var json = await File.ReadAllTextAsync(FilePath, Encoding.UTF8);
             _semaphoreSlim.Release();
-
-            try
-            {
-                Entries = JsonConvert.DeserializeObject<Dictionary<string, object>>(json,
-                    new JsonSerializerSettings() {TypeNameHandling = TypeNameHandling.Auto});
-            }
-            catch (JsonSerializationException e)
-            {
-                // Move the file to a .unsupported file
-                // and start fresh
-                WCLogger.LogError(e);
-                WCLogger.LogError("Cannot load JSON file, moving data to .unsupported file to force continue");
-                if (File.Exists(FilePath + ".unsupported"))
-                    File.Move(FilePath + ".unsupported", FilePath + "." + Guid.NewGuid() + ".unsupported");
-                File.Move(FilePath, FilePath + ".unsupported");
-                Entries = new Dictionary<string, object>();
-            }
+            Entries = JsonConvert.DeserializeObject<Dictionary<string, object>>(json,
+                new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.Auto });
         }
     }
 }


### PR DESCRIPTION
This PR will require that the session file can be de-serialized. If it can't be de-serialized, the entire Core init process should fail.