### PR TITLE
feat: allow session expiry to be configurable

### DIFF
--- a/WalletConnectSharp.Sign/Engine.cs
+++ b/WalletConnectSharp.Sign/Engine.cs
@@ -306,8 +306,8 @@ namespace WalletConnectSharp.Sign
             var id = await MessageHandler.SendRequest<SessionPropose, SessionProposeResponse>(topic, proposal);
             
             logger.Log($"Got back {id} as request pending id");
-            
-            var expiry = Clock.CalculateExpiry(Clock.FIVE_MINUTES);
+
+            var expiry = Clock.CalculateExpiry(options.Expiry);
 
             await PrivateThis.SetProposal(id, new ProposalStruct()
             {

--- a/WalletConnectSharp.Sign/Models/Engine/ConnectOptions.cs
+++ b/WalletConnectSharp.Sign/Models/Engine/ConnectOptions.cs
@@ -164,5 +164,17 @@ namespace WalletConnectSharp.Sign.Models.Engine
             Relays = options;
             return this;
         }
+
+        public ConnectOptions WithExpiry(long seconds)
+        {
+            Expiry = seconds;
+            return this;
+        }
+        
+        public ConnectOptions WithExpiry(TimeSpan expiry)
+        {
+            Expiry = (long)expiry.TotalSeconds;
+            return this;
+        }
     }
 }

--- a/WalletConnectSharp.Sign/Models/Engine/ConnectOptions.cs
+++ b/WalletConnectSharp.Sign/Models/Engine/ConnectOptions.cs
@@ -1,5 +1,6 @@
 using Newtonsoft.Json;
 using WalletConnectSharp.Common.Model.Relay;
+using WalletConnectSharp.Common.Utils;
 using WalletConnectSharp.Core.Models.Relay;
 
 namespace WalletConnectSharp.Sign.Models.Engine
@@ -41,6 +42,13 @@ namespace WalletConnectSharp.Sign.Models.Engine
         /// </summary>
         [JsonProperty("relays")]
         public ProtocolOptions Relays;
+
+        /// <summary>
+        /// How long the session will be open before it's considered expired. If the session
+        /// is expired, then Extend must be called on the session to extend the expiry
+        /// </summary>
+        [JsonProperty("expiry")]
+        public long Expiry = Clock.FIVE_MINUTES;
 
         /// <summary>
         /// Create blank options with no required namespaces

--- a/WalletConnectSharp.Sign/Models/Engine/ConnectOptions.cs
+++ b/WalletConnectSharp.Sign/Models/Engine/ConnectOptions.cs
@@ -165,12 +165,22 @@ namespace WalletConnectSharp.Sign.Models.Engine
             return this;
         }
 
+        /// <summary>
+        /// Set the expiry duration for the session
+        /// </summary>
+        /// <param name="seconds">The amount of seconds that should pass before the session expires</param>
+        /// <returns>This object, acts a builder function</returns>
         public ConnectOptions WithExpiry(long seconds)
         {
             Expiry = seconds;
             return this;
         }
         
+        /// <summary>
+        /// Set the expiry duration for the session
+        /// </summary>
+        /// <param name="expiry">The amount of time that should pass before the session expires</param>
+        /// <returns>This object, acts a builder function</returns>
         public ConnectOptions WithExpiry(TimeSpan expiry)
         {
             Expiry = (long)expiry.TotalSeconds;


### PR DESCRIPTION
This PR allows the dApp to configure how long a session will remain open before it expires. This can be configured in the `ConnectOptions` passed into `Connect()`. The default is 5 minutes.