### PR TITLE
feat: add type safe check when sending custom request / response types

### DIFF
--- a/Core Modules/WalletConnectSharp.Common/Utils/TypeSafety.cs
+++ b/Core Modules/WalletConnectSharp.Common/Utils/TypeSafety.cs
@@ -13,12 +13,15 @@ public static class TypeSafety
         // to / from JSON should tell us
         // if it's serializer safe, since
         // we are using the serializer to test
-        UnsafeJsonRewrap<T, T>(testObject);
+        UnsafeJsonRewrap<T, T>(testObject, Settings);
     }
 
-    public static TR UnsafeJsonRewrap<T, TR>(this T source)
+    public static TR UnsafeJsonRewrap<T, TR>(this T source, JsonSerializerSettings settings = null)
     {
-        var json = JsonConvert.SerializeObject(source);
+        var json = settings == null ? 
+            JsonConvert.SerializeObject(source) : 
+            JsonConvert.SerializeObject(source, settings);
+        
         return JsonConvert.DeserializeObject<TR>(json);
     }
 }

--- a/Core Modules/WalletConnectSharp.Common/Utils/TypeSafety.cs
+++ b/Core Modules/WalletConnectSharp.Common/Utils/TypeSafety.cs
@@ -1,0 +1,24 @@
+﻿using Newtonsoft.Json;
+
+namespace WalletConnectSharp.Common.Utils;
+
+public static class TypeSafety
+{
+    private static JsonSerializerSettings Settings =
+        new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.Auto };
+    
+    public static void EnsureTypeSerializerSafe<T>(T testObject)
+    {
+        // unwrapping and rewrapping the object
+        // to / from JSON should tell us
+        // if it's serializer safe, since
+        // we are using the serializer to test
+        UnsafeJsonRewrap<T, T>(testObject);
+    }
+
+    public static TR UnsafeJsonRewrap<T, TR>(this T source)
+    {
+        var json = JsonConvert.SerializeObject(source);
+        return JsonConvert.DeserializeObject<TR>(json);
+    }
+}


### PR DESCRIPTION
This PR will give end developers more visiblity when a custom request / response type is not JSON.NET serializer safe. This check is only performed once when the custom type is first used. A [JsonSerializationException](https://www.newtonsoft.com/json/help/html/t_newtonsoft_json_jsonserializationexception.htm) is thrown when a type is considered unsafe.