### PR TITLE
Decrease pause check interval from 2ms to 1s

### DIFF
--- a/WalletConnectSharp.Core/Controllers/Relayer.cs
+++ b/WalletConnectSharp.Core/Controllers/Relayer.cs
@@ -473,7 +473,7 @@ namespace WalletConnectSharp.Core.Controllers
                 while (Connecting)
                 {
                     WCLogger.Log("[Relayer] Waiting for connection to open");
-                    await Task.Delay(2);
+                    await Task.Delay(TimeSpan.FromSeconds(1));
                 }
 
                 if (!Connected && !Connecting)


### PR DESCRIPTION
Restores ae1c2a00 which was accidentally overriden during merge conflict resolution.