### PR TITLE
fix: Engine uses OrderedKeys which can be empty

### DIFF
--- a/WalletConnectSharp.Sign/Engine.cs
+++ b/WalletConnectSharp.Sign/Engine.cs
@@ -683,7 +683,7 @@ namespace WalletConnectSharp.Sign
             if (string.IsNullOrWhiteSpace(chainId))
             {
                 var sessionData = Client.Session.Get(topic);
-                var firstRequiredNamespace = sessionData.RequiredNamespaces.OrderedKeys[0];
+                var firstRequiredNamespace = sessionData.RequiredNamespaces.Keys.First();
                 defaultChainId = sessionData.RequiredNamespaces[firstRequiredNamespace].Chains[0];
             }
             else


### PR DESCRIPTION
https://github.com/WalletConnect/WalletConnectSharp/pull/156#issuecomment-1823032496