### PR TITLE
fix: defaults loading in Address Provider

### DIFF
--- a/Tests/WalletConnectSharp.Sign.Test/SignTests.cs
+++ b/Tests/WalletConnectSharp.Sign.Test/SignTests.cs
@@ -395,6 +395,10 @@ namespace WalletConnectSharp.Sign.Test
             
             var dappClient = ClientA;
             var walletClient = ClientB;
+
+            await dappClient.AddressProvider.LoadDefaultsAsync();
+            await walletClient.AddressProvider.LoadDefaultsAsync();
+            
             if (!dappClient.AddressProvider.HasDefaultSession && !walletClient.AddressProvider.HasDefaultSession)
             {
                 var testAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
@@ -579,6 +583,8 @@ namespace WalletConnectSharp.Sign.Test
 
             var defaultSessionTopic = _cryptoFixture.ClientA.AddressProvider.DefaultSession.Topic;
 
+            Assert.NotNull(defaultSessionTopic);
+
             _cryptoFixture.StorageOverrideA = _cryptoFixture.ClientA.Core.Storage;
             _cryptoFixture.StorageOverrideB = _cryptoFixture.ClientB.Core.Storage;
 
@@ -586,10 +592,9 @@ namespace WalletConnectSharp.Sign.Test
             
             await _cryptoFixture.DisposeAndReset();
             
-            _testOutputHelper.WriteLine(string.Join(",", _cryptoFixture.ClientB.Core.Crypto.KeyChain.Keychain.Values));
-
             await Task.Delay(500);
 
+            await _cryptoFixture.ClientA.AddressProvider.LoadDefaultsAsync();
             var reloadedDefaultSessionTopic = _cryptoFixture.ClientA.AddressProvider.DefaultSession.Topic;
             
             Assert.Equal(defaultSessionTopic, reloadedDefaultSessionTopic);

--- a/WalletConnectSharp.Sign/Interfaces/IAddressProvider.cs
+++ b/WalletConnectSharp.Sign/Interfaces/IAddressProvider.cs
@@ -16,10 +16,7 @@ public interface IAddressProvider : IModule
     string DefaultChainId { get; }
     
     ISession Sessions { get; }
-
-
-    Task InitAsync();
-
+    
     Task SetDefaultNamespaceAsync(string @namespace);
 
     Task SetDefaultChainIdAsync(string chainId);
@@ -27,4 +24,6 @@ public interface IAddressProvider : IModule
     Caip25Address CurrentAddress(string chainId = null, SessionStruct session = default);
 
     IEnumerable<Caip25Address> AllAddresses(string @namespace = null, SessionStruct session = default);
+    
+    public Task LoadDefaultsAsync();
 }

--- a/WalletConnectSharp.Sign/WalletConnectSignClient.cs
+++ b/WalletConnectSharp.Sign/WalletConnectSignClient.cs
@@ -488,7 +488,6 @@ namespace WalletConnectSharp.Sign
             await Session.Init();
             await Proposal.Init();
             await Engine.Init();
-            await AddressProvider.InitAsync();
         }
 
         public void Dispose()


### PR DESCRIPTION
- Don’t automatically load defaults on init
- Don’t load expired session